### PR TITLE
Remove confusing bin subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ After you find MPI installations on your system, you can register them
 using `mpienv add` command.
 
 ```bash
-$ mpienv add /opt/local/bin
+$ mpienv add /opt/local
 ```
 
 Let's check if the MPI is added properly:


### PR DESCRIPTION
It seems the script finds MPI installations from the subdirectory of the path you specifies.
https://github.com/keisukefukuda/mpienv/blob/7dfea734a03bcdcb63a4e95451af43dfc3a25345/common.py#L122
I think having `bin` in this example is a little bit confusing.