### PR TITLE
fix autodiscover crashes when dirpath contains special character

### DIFF
--- a/bin/autodiscover.py
+++ b/bin/autodiscover.py
@@ -78,7 +78,7 @@ def list_mpiexec(dirpath):
       * Otherwise, one is randomly chosen
     """
 
-    lst = glob.glob(os.path.join(dirpath, 'bin', '*mpiexec*'))
+    lst = glob.glob(os.path.join(glob.escape(dirpath), 'bin', '*mpiexec*'))
     link_rel = {}
 
     # As an exception, we need to exclude binaries like


### PR DESCRIPTION
autodiscover subcommand crashes when directory name contains `glob.glob()`'s special character which like "[", "?" and "*"
In my environment, this directory name occur crash:
```
% find .vim/** | grep "\["
.vim/bundle/vimtex/test/issues/237/[code college-1] title
.vim/bundle/vimtex/test/issues/237/[code college-1] title/test.tex
```

Error detail
```
% mpienv autodiscover
--------------------------------------
Found /usr/local/bin/mpiexec
<mpienv.mpich.Mpich object at 0x102934cc0>
--------------------------------------
Found /usr/local/Cellar/mpich/3.2.1_2/bin/mpiexec
<mpienv.mpich.Mpich object at 0x1029349b0>
Traceback (most recent call last):
  File "/Users/k/.mpienv/bin/autodiscover.py", line 201, in <module>
    main()
  File "/Users/k/.mpienv/bin/autodiscover.py", line 197, in main
    done = investigate_path(dirpath, to_add, done)
  File "/Users/k/.mpienv/bin/autodiscover.py", line 121, in investigate_path
    for mpiexec in list_mpiexec(path):
  File "/Users/k/.mpienv/bin/autodiscover.py", line 81, in list_mpiexec
    lst = glob.glob(os.path.join(dirpath, 'bin', '*mpiexec*'))
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/glob.py", line 20, in glob
    return list(iglob(pathname, recursive=recursive))
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/glob.py", line 71, in _iglob
    for dirname in dirs:
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/glob.py", line 71, in _iglob
    for dirname in dirs:
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/glob.py", line 72, in _iglob
    for name in glob_in_dir(dirname, basename, dironly):
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/glob.py", line 83, in _glob1
    return fnmatch.filter(names, pattern)
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/fnmatch.py", line 52, in filter
    match = _compile_pattern(pat)
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/fnmatch.py", line 46, in _compile_pattern
    return re.compile(res).match
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/re.py", line 233, in compile
    return _compile(pattern, flags)
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/re.py", line 301, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/sre_compile.py", line 562, in compile
    p = sre_parse.parse(p, flags)
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/sre_parse.py", line 855, in parse
    p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, 0)
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/sre_parse.py", line 416, in _parse_sub
    not nested and not items))
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/sre_parse.py", line 765, in _parse
    p = _parse_sub(source, state, sub_verbose, nested + 1)
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/sre_parse.py", line 416, in _parse_sub
    not nested and not items))
  File "/Users/k/.pyenv/versions/3.6.6/lib/python3.6/sre_parse.py", line 553, in _parse
    raise source.error(msg, len(this) + 1 + len(that))
sre_constants.error: bad character range e-1 at position 16
```